### PR TITLE
Sugarchain: FIX: Travis for Yespower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ script:
     - if [ -z "$NO_DEPENDS" ]; then depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE; fi
     - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
     - mkdir build && cd build
-    - ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
+    - ../configure CFLAGS="-I$YESPOWER_PATH $YESPOWER_OPTION" --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - make distdir VERSION=$HOST
     - cd sugarchain-$HOST
     - ./configure CFLAGS="-I$YESPOWER_PATH $YESPOWER_OPTION" --cache-file=../config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)


### PR DESCRIPTION
Changes:
 * Add CFLAGS for Yespower
`-fPIE -Wall -O2 -fomit-frame-pointer`
 * Add `-msse2` to Linux32. But Win32 is not applied because slow `make check`
 * `make deploy` on macOS

Reference:
 * `-msse2`
```
> Please check below list
> 
> ===
> ARM (no such function)
> -Wall -O2 -fomit-frame-pointer
> 
> Win32 (need -msse2)
> -Wall *-msse2* -O2 -fomit-frame-pointer
> 
> Linux32 (need -msse2)
> -Wall *-msse2* -O2 -fomit-frame-pointer
> 
> Win64 (already implied so not needed)
> -Wall -O2 -fomit-frame-pointer
> 
> Linux64 (already implied so not needed)
> -Wall -O2 -fomit-frame-pointer
> 
> macOS (already implied so not needed)
> -Wall -O2 -fomit-frame-pointer
> ===
> 
> Am I right?

This looks OK to me.

Alexander
```

 * `-fPIE` ignore warnings
```
> Can I ignore this warning safely?

Yes.

> I used "-fPIE -Wall -O2 -fomit-frame-pointer" for the travis. Should I
> remove that "-fPIE"?

No.  It's needed on other systems.

> crypto/yespower-1.0.0/sha256.c:1:0: warning: -fPIC ignored for target (all
> code is position independent) [enabled by default]

Alexander
```

 * `--disable-share` on Windows 32/64-Bit
```
> build on Win32
> ```bash
> primitives/.libs/libbitcoinconsensus_la-block.o: In function
> `ZN25zero_after_free_allocatorIcE10deallocateEPcj':
> /home/ubuntu/build/sugarchain/distsrc-i686-w64-mingw32/src/./support/allocators/zeroafterfree.h:40:
> undefined reference to `memory_cleanse(void*, unsigned int)'
> /home/ubuntu/build/sugarchain/distsrc-i686-w64-mingw32/src/./support/allocators/zeroafterfree.h:40:
> undefined reference to `memory_cleanse(void*, unsigned int)'
> /home/ubuntu/build/sugarchain/distsrc-i686-w64-mingw32/src/./support/allocators/zeroafterfree.h:40:
> undefined reference to `memory_cleanse(void*, unsigned int)'
> collect2: error: ld returned 1 exit status
> make[2]: *** [libbitcoinconsensus.la] Error 1
> ```

This one looks similar to what was encountered in:

https://github.com/dashpay/dash/pull/2531

Unfortunately, you won't be able to reuse Dash's fix for it because
CVectorWriter is Dash-specific.
```