### PR TITLE
Sugarchain: add DNSSEED for testnet

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -426,12 +426,8 @@ public:
         vSeeds.clear();
         // TODO.SUGAR - seeder
         // nodes with support for servicebits filtering should be at the top
-        // vSeeds.emplace_back("testnet.seed.sugarchain.info");
         vSeeds.emplace_back("seed-testnet.sugarchain.org");
-        // vSeeds.emplace_back("testnet-seed.bitcoin.jonasschnelli.ch");
-        // vSeeds.emplace_back("seed.tbtc.petertodd.org");
-        // vSeeds.emplace_back("seed.testnet.bitcoin.sprovoost.nl");
-        // vSeeds.emplace_back("testnet-seed.bluematt.me"); // Just a static list of stable node(s), only supports x9
+        vSeeds.emplace_back("seed-testnet.cryptozeny.com");
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,66);  // legacy: starting with T (upper)
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,128); // p2sh-segwit: starting with t (lower)


### PR DESCRIPTION
changes:
```
[x] add: seed-testnet.sugarchain.org | amzon AWS | South Korea | 52.79.58.49
[x] add: seed-testnet.cryptozeny.com | Vultr | New York | 216.155.135.96
```

todo:
```
[ ] add mainnet nodes
```

ref:
sugarchain seeder url: https://github.com/sugarchain-project/sugarchain-seeder

tested cmd:
```
./src/qt/sugarchain-qt -testnet -server=1 -rpcuser=rpcuser -rpcpassword=rpcpassword -dns=1 -dnsseed=1 -forcednsseed=1 -listen=1
```

tested output:
```
2019-06-26 01:50:05 4 addresses found from DNS seeds
2019-06-26 01:50:05 dnsseed thread exit
```